### PR TITLE
ci: add automated release workflow with GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,31 +3,20 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
-
-permissions:
-  contents: write
+      - 'v*.*.*'
 
 jobs:
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.21"
-          check-latest: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v4
         with:
-          distribution: goreleaser
           version: latest
-          args: release --clean
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,28 @@
+project_name: k8spreview
+
+builds:
+  - binary: k8spreview
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: "checksums.txt"
+
+release:
+  github:
+    owner: johnoct
+    name: k8spreview

--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ k8spreview -version
 # Run with example file
 make run
 ```
+ 
+## Automated Releases
+
+We use GoReleaser to build and publish binaries automatically on new tags.
+To create a release:
+```bash
+make release v=x.y.z
+```
+This will:
+1. Update `pkg/version/version.go`.
+2. Commit and push the change and tag.
+3. Trigger the GitHub Actions release workflow to build binaries for all platforms
+   and publish them to the GitHub release.
+
+Pushing any new tag matching `v*.*.*` will also trigger the release workflow.
 
 ### Navigation
 


### PR DESCRIPTION
Add a GitHub Actions workflow and GoReleaser config to automatically build and publish binaries when tags are pushed.\n\nFeatures:\n- .goreleaser.yml defines builds for Linux, macOS, and Windows (amd64 & arm64)\n- release.yml triggers GoReleaser on any tag matching v*.*.*\n- README updated with Automated Releases section.