### PR TITLE
fix: match service selectors against pod template labels

### DIFF
--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -87,9 +87,6 @@ func TestFindRelatedResources(t *testing.T) {
 		Kind:       "Deployment",
 		Metadata: k8s.Metadata{
 			Name: "test-deployment",
-			Labels: map[string]string{
-				"app": "test",
-			},
 		},
 		Spec: map[string]interface{}{
 			"template": map[string]interface{}{


### PR DESCRIPTION
## Summary
- ensure Service selector matching considers pod template labels for Deployments and StatefulSets
- add helper for extracting labels from resources
- cover missing metadata labels case in tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890043ee938832d93bcc11002954fda