### PR TITLE
test: assert namespace and API version in parsing

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -18,7 +18,7 @@ type Metadata struct {
 
 // Resource represents a Kubernetes resource
 type Resource struct {
-	ApiVersion string      `yaml:"apiVersion"`
+    APIVersion string      `yaml:"apiVersion"`
 	Kind       string      `yaml:"kind"`
 	Metadata   Metadata    `yaml:"metadata"`
 	Spec       interface{} `yaml:"spec,omitempty"`

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -51,27 +51,39 @@ spec:
 	}
 
 	// Check first resource (Service)
-	if resources[0].Kind != "Service" {
-		t.Errorf("Expected Service, got %s", resources[0].Kind)
-	}
-	if resources[0].Metadata.Name != "test-service" {
-		t.Errorf("Expected test-service, got %s", resources[0].Metadata.Name)
-	}
+        if resources[0].Kind != "Service" {
+                t.Errorf("Expected Service, got %s", resources[0].Kind)
+        }
+        if resources[0].Metadata.Name != "test-service" {
+                t.Errorf("Expected test-service, got %s", resources[0].Metadata.Name)
+        }
+        if resources[0].Metadata.Namespace != "default" {
+                t.Errorf("Expected namespace default, got %s", resources[0].Metadata.Namespace)
+        }
+        if resources[0].APIVersion != "v1" {
+                t.Errorf("Expected API version v1, got %s", resources[0].APIVersion)
+        }
 
 	// Check second resource (Deployment)
-	if resources[1].Kind != "Deployment" {
-		t.Errorf("Expected Deployment, got %s", resources[1].Kind)
-	}
-	if resources[1].Metadata.Name != "test-deployment" {
-		t.Errorf("Expected test-deployment, got %s", resources[1].Metadata.Name)
-	}
+        if resources[1].Kind != "Deployment" {
+                t.Errorf("Expected Deployment, got %s", resources[1].Kind)
+        }
+        if resources[1].Metadata.Name != "test-deployment" {
+                t.Errorf("Expected test-deployment, got %s", resources[1].Metadata.Name)
+        }
+        if resources[1].Metadata.Namespace != "default" {
+                t.Errorf("Expected namespace default, got %s", resources[1].Metadata.Namespace)
+        }
+        if resources[1].APIVersion != "apps/v1" {
+                t.Errorf("Expected API version apps/v1, got %s", resources[1].APIVersion)
+        }
 }
 
 func TestFindRelatedResources(t *testing.T) {
 	// Create test resources
-	service := k8s.Resource{
-		ApiVersion: "v1",
-		Kind:       "Service",
+        service := k8s.Resource{
+                APIVersion: "v1",
+                Kind:       "Service",
 		Metadata: k8s.Metadata{
 			Name: "test-service",
 		},
@@ -82,9 +94,9 @@ func TestFindRelatedResources(t *testing.T) {
 		},
 	}
 
-	deployment := k8s.Resource{
-		ApiVersion: "apps/v1",
-		Kind:       "Deployment",
+        deployment := k8s.Resource{
+                APIVersion: "apps/v1",
+                Kind:       "Deployment",
 		Metadata: k8s.Metadata{
 			Name: "test-deployment",
 		},

--- a/pkg/ui/model.go
+++ b/pkg/ui/model.go
@@ -49,7 +49,7 @@ func NewModel(resources []k8s.Resource) Model {
 	for i, res := range resources {
 		items[i] = item{
 			title:       fmt.Sprintf("%s/%s", res.Kind, res.Metadata.Name),
-			description: fmt.Sprintf("API Version: %s, Namespace: %s", res.ApiVersion, res.Metadata.Namespace),
+                        description: fmt.Sprintf("API Version: %s, Namespace: %s", res.APIVersion, res.Metadata.Namespace),
 			resource:    res,
 		}
 	}


### PR DESCRIPTION
## Summary
- rename Resource.ApiVersion to APIVersion
- verify parsed resources have correct namespace and API version

## Testing
- `go test ./pkg/k8s`


------
https://chatgpt.com/codex/tasks/task_e_68900edeada0832dace7c7c1b5a975ec