### PR TITLE
Handle selects relations in graph

### DIFF
--- a/pkg/ui/model.go
+++ b/pkg/ui/model.go
@@ -182,12 +182,20 @@ func (m Model) generateGraph() string {
 		for _, rel := range relations {
 			var r relationship
 			if strings.HasPrefix(rel, "→") {
-				parts := strings.Split(strings.TrimPrefix(rel, "→ "), "/")
+				relationText := strings.TrimPrefix(rel, "→ ")
+				parts := strings.SplitN(relationText, " ", 2)
 				if len(parts) == 2 {
-					r = relationship{
-						from:     nodeKey,
-						to:       fmt.Sprintf("%s/%s", parts[0], strings.TrimSpace(parts[1])),
-						relation: "uses",
+					target := strings.Split(parts[1], "/")
+					if len(target) == 2 {
+						relType := "uses"
+						if parts[0] == "Selects" {
+							relType = "selects"
+						}
+						r = relationship{
+							from:     nodeKey,
+							to:       fmt.Sprintf("%s/%s", target[0], strings.TrimSpace(target[1])),
+							relation: relType,
+						}
 					}
 				}
 			} else if strings.HasPrefix(rel, "←") {

--- a/pkg/ui/model_test.go
+++ b/pkg/ui/model_test.go
@@ -1,0 +1,47 @@
+package ui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"k8spreview/pkg/k8s"
+)
+
+func TestGenerateGraphServiceSelectsDeployment(t *testing.T) {
+	service := k8s.Resource{
+		ApiVersion: "v1",
+		Kind:       "Service",
+		Metadata:   k8s.Metadata{Name: "test-service"},
+		Spec: map[string]interface{}{
+			"selector": map[string]interface{}{
+				"app": "test",
+			},
+		},
+	}
+
+	deployment := k8s.Resource{
+		ApiVersion: "apps/v1",
+		Kind:       "Deployment",
+		Metadata:   k8s.Metadata{Name: "test-deployment"},
+		Spec: map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"app": "test",
+					},
+				},
+			},
+		},
+	}
+
+	m := NewModel([]k8s.Resource{service, deployment})
+	graph := m.generateGraph()
+
+	re := regexp.MustCompile("\x1b\\[[0-9;]*m")
+	clean := re.ReplaceAllString(graph, "")
+
+	if !strings.Contains(clean, "test-service <──selects──── test-deployment") {
+		t.Fatalf("expected selects edge between service and deployment, got:\n%s", clean)
+	}
+}


### PR DESCRIPTION
## Summary
- detect "Selects" relations and render selects edges
- add test verifying selects edge for Service -> Deployment

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68900edba510832d8d7068bdd66ed7e0